### PR TITLE
api: tm: shaper packet mode 

### DIFF
--- a/example/traffic_mgmt/odp_traffic_mgmt.c
+++ b/example/traffic_mgmt/odp_traffic_mgmt.c
@@ -62,8 +62,8 @@ static const odp_init_t ODP_INIT_PARAMS = {
 
 static profile_params_set_t COMPANY_PROFILE_PARAMS = {
 	.shaper_params = {
-		.commit_bps = 50  * MBPS,  .commit_burst      = 1000000,
-		.peak_bps   = 0,           .peak_burst        = 0,
+		.commit_rate = 50  * MBPS, .commit_burst      = 1000000,
+		.peak_rate   = 0,          .peak_burst        = 0,
 		.dual_rate  = FALSE,       .shaper_len_adjust = 20
 	},
 
@@ -95,8 +95,8 @@ static profile_params_set_t COMPANY_PROFILE_PARAMS = {
 
 static profile_params_set_t COS0_PROFILE_PARAMS = {
 	.shaper_params = {
-		.commit_bps = 1 * MBPS,  .commit_burst      = 100000,
-		.peak_bps   = 4 * MBPS,  .peak_burst        = 200000,
+		.commit_rate = 1 * MBPS, .commit_burst      = 100000,
+		.peak_rate   = 4 * MBPS, .peak_burst        = 200000,
 		.dual_rate  = FALSE,     .shaper_len_adjust = 20
 	},
 
@@ -128,8 +128,8 @@ static profile_params_set_t COS0_PROFILE_PARAMS = {
 
 static profile_params_set_t COS1_PROFILE_PARAMS = {
 	.shaper_params = {
-		.commit_bps = 500  * KBPS,  .commit_burst      = 50000,
-		.peak_bps   = 1500 * KBPS,  .peak_burst        = 150000,
+		.commit_rate = 500  * KBPS, .commit_burst      = 50000,
+		.peak_rate   = 1500 * KBPS, .peak_burst        = 150000,
 		.dual_rate  = FALSE,        .shaper_len_adjust = 20
 	},
 
@@ -161,8 +161,8 @@ static profile_params_set_t COS1_PROFILE_PARAMS = {
 
 static profile_params_set_t COS2_PROFILE_PARAMS = {
 	.shaper_params = {
-		.commit_bps = 200 * KBPS,  .commit_burst      = 20000,
-		.peak_bps   = 400 * KBPS,  .peak_burst        = 40000,
+		.commit_rate = 200 * KBPS, .commit_burst      = 20000,
+		.peak_rate   = 400 * KBPS, .peak_burst        = 40000,
 		.dual_rate  = FALSE,       .shaper_len_adjust = 20
 	},
 
@@ -194,8 +194,8 @@ static profile_params_set_t COS2_PROFILE_PARAMS = {
 
 static profile_params_set_t COS3_PROFILE_PARAMS = {
 	.shaper_params = {
-		.commit_bps = 100 * KBPS,  .commit_burst      = 5000,
-		.peak_bps   = 0,           .peak_burst        = 0,
+		.commit_rate = 100 * KBPS, .commit_burst      = 5000,
+		.peak_rate   = 0,          .peak_burst        = 0,
 		.dual_rate  = FALSE,       .shaper_len_adjust = 20
 	},
 
@@ -272,8 +272,8 @@ static uint32_t create_profile_set(profile_params_set_t *profile_params_set,
 
 	odp_tm_shaper_params_init(&shaper_params);
 	shaper                          = &profile_params_set->shaper_params;
-	shaper_params.commit_bps        = shaper->commit_bps   * shaper_scale;
-	shaper_params.peak_bps          = shaper->peak_bps     * shaper_scale;
+	shaper_params.commit_rate       = shaper->commit_rate  * shaper_scale;
+	shaper_params.peak_rate         = shaper->peak_rate    * shaper_scale;
 	shaper_params.commit_burst      = shaper->commit_burst * shaper_scale;
 	shaper_params.peak_burst        = shaper->peak_burst   * shaper_scale;
 	shaper_params.dual_rate         = shaper->dual_rate;

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -746,20 +746,32 @@ typedef enum {
  */
 typedef struct {
 	/** The committed information rate for this shaper profile.  The units
-	 * for this integer are always in bits per second. */
-	uint64_t commit_bps;
+	 * for this integer is in bits per second when packet_mode is
+	 * not TRUE while packets per second when packet mode is TRUE.
+	 */
+	union {
+		uint64_t commit_bps; /**< Commit information rate in bps */
+		uint64_t commit_rate; /**< Commit information rate */
+	};
 
 	/** The peak information rate for this shaper profile.  The units for
-	 * this integer are always in bits per second. */
-	uint64_t peak_bps;
+	 * this integer is in bits per second when packet_mode is
+	 * not TRUE while in packets per second when packet mode is TRUE.
+	 */
+	union {
+		uint64_t peak_bps; /**< Peak information rate in bps */
+		uint64_t peak_rate; /**< Peak information rate */
+	};
 
 	/** The commit burst tolerance for this shaper profile.  The units for
-	 * this field are always bits.  This value sets an upper limit for the
+	 * this field is bits when packet_mode is not TRUE and packets when
+	 * packet_mode is TRUE.  This value sets an upper limit for the
 	 * size of the commitCnt. */
 	uint32_t commit_burst;
 
 	/** The peak burst tolerance for this shaper profile.  The units for
-	 * this field are always bits.  This value sets an upper limit for the
+	 * this field in bits when packet_mode is not TRUE and packets
+	 * when packet_mode is TRUE. This value sets an upper limit for the
 	 * size of the peakCnt. */
 	uint32_t peak_burst;
 
@@ -771,7 +783,9 @@ typedef struct {
 	 * to a value approximating the "time" (in units of bytes) taken by
 	 * the Ethernet preamble and Inter Frame Gap.  Traditionally this
 	 * would be the value 20 (8 + 12), but in same cases can be as low as
-	 * 9 (4 + 5). */
+	 * 9 (4 + 5).
+	 * This field is ignored when packet_mode is TRUE.
+	 */
 	int8_t shaper_len_adjust;
 
 	/** If dual_rate is TRUE it indicates the desire for the
@@ -780,6 +794,12 @@ typedef struct {
 	 * implementation specific, but in any case require a non-zero set of
 	 * both commit and peak parameters. */
 	odp_bool_t dual_rate;
+
+	/** If packet_mode is TRUE it indicates that shaper should work
+	 * in packet mode ignoring lengths of packet and hence shaping
+	 * traffic in packet's per second as opposed to bytes per second.
+	 */
+	odp_bool_t packet_mode;
 } odp_tm_shaper_params_t;
 
 /** odp_tm_shaper_params_init() must be called to initialize any

--- a/include/odp/api/spec/traffic_mngr.h
+++ b/include/odp/api/spec/traffic_mngr.h
@@ -750,7 +750,8 @@ typedef struct {
 	 * not TRUE while packets per second when packet mode is TRUE.
 	 */
 	union {
-		uint64_t commit_bps; /**< Commit information rate in bps */
+		/**< @deprecated Use commit_rate instead */
+		uint64_t ODP_DEPRECATE(commit_bps);
 		uint64_t commit_rate; /**< Commit information rate */
 	};
 
@@ -759,7 +760,8 @@ typedef struct {
 	 * not TRUE while in packets per second when packet mode is TRUE.
 	 */
 	union {
-		uint64_t peak_bps; /**< Peak information rate in bps */
+		/**< @deprecated Use peak_rate instead */
+		uint64_t ODP_DEPRECATE(peak_bps);
 		uint64_t peak_rate; /**< Peak information rate */
 	};
 

--- a/platform/linux-generic/odp_traffic_mngr.c
+++ b/platform/linux-generic/odp_traffic_mngr.c
@@ -611,8 +611,8 @@ static void tm_shaper_params_cvt_to(const odp_tm_shaper_params_t *shaper_params,
 	uint32_t min_time_delta;
 	int64_t  commit_burst, peak_burst;
 
-	commit_rate = tm_bps_to_rate(shaper_params->commit_bps);
-	if ((shaper_params->commit_bps == 0) || (commit_rate == 0)) {
+	commit_rate = tm_bps_to_rate(shaper_params->commit_rate);
+	if ((shaper_params->commit_rate == 0) || (commit_rate == 0)) {
 		tm_shaper_params->max_commit_time_delta = 0;
 		tm_shaper_params->max_peak_time_delta   = 0;
 		tm_shaper_params->commit_rate           = 0;
@@ -629,8 +629,8 @@ static void tm_shaper_params_cvt_to(const odp_tm_shaper_params_t *shaper_params,
 	max_commit_time_delta = tm_max_time_delta(commit_rate);
 	commit_burst = (int64_t)shaper_params->commit_burst;
 
-	peak_rate = tm_bps_to_rate(shaper_params->peak_bps);
-	if ((shaper_params->peak_bps == 0) || (peak_rate == 0)) {
+	peak_rate = tm_bps_to_rate(shaper_params->peak_rate);
+	if ((shaper_params->peak_rate == 0) || (peak_rate == 0)) {
 		peak_rate = 0;
 		max_peak_time_delta = 0;
 		peak_burst = 0;
@@ -670,8 +670,8 @@ static void tm_shaper_params_cvt_from(tm_shaper_params_t     *tm_shaper_params,
 	commit_burst = tm_shaper_params->max_commit >> (26 - 3);
 	peak_burst = tm_shaper_params->max_peak >> (26 - 3);
 
-	odp_shaper_params->commit_bps = commit_bps;
-	odp_shaper_params->peak_bps = peak_bps;
+	odp_shaper_params->commit_rate = commit_bps;
+	odp_shaper_params->peak_rate = peak_bps;
 	odp_shaper_params->commit_burst = (uint32_t)commit_burst;
 	odp_shaper_params->peak_burst = (uint32_t)peak_burst;
 	odp_shaper_params->shaper_len_adjust = tm_shaper_params->len_adjust;

--- a/test/validation/api/traffic_mngr/traffic_mngr.c
+++ b/test/validation/api/traffic_mngr/traffic_mngr.c
@@ -2188,9 +2188,9 @@ static void check_shaper_profile(char *shaper_name, uint32_t shaper_idx)
 	memset(&shaper_params, 0, sizeof(shaper_params));
 	rc = odp_tm_shaper_params_read(profile, &shaper_params);
 	CU_ASSERT(rc == 0);
-	CU_ASSERT(approx_eq64(shaper_params.commit_bps,
+	CU_ASSERT(approx_eq64(shaper_params.commit_rate,
 			      shaper_idx * MIN_COMMIT_BW));
-	CU_ASSERT(approx_eq64(shaper_params.peak_bps,
+	CU_ASSERT(approx_eq64(shaper_params.peak_rate,
 			      shaper_idx * MIN_PEAK_BW));
 	CU_ASSERT(approx_eq32(shaper_params.commit_burst,
 			      shaper_idx * MIN_COMMIT_BURST));
@@ -2215,8 +2215,8 @@ static void traffic_mngr_test_shaper_profile(void)
 	for (idx = 1; idx <= NUM_SHAPER_TEST_PROFILES; idx++) {
 		snprintf(shaper_name, sizeof(shaper_name),
 			 "shaper_profile_%" PRIu32, idx);
-		shaper_params.commit_bps   = idx * MIN_COMMIT_BW;
-		shaper_params.peak_bps     = idx * MIN_PEAK_BW;
+		shaper_params.commit_rate  = idx * MIN_COMMIT_BW;
+		shaper_params.peak_rate    = idx * MIN_PEAK_BW;
 		shaper_params.commit_burst = idx * MIN_COMMIT_BURST;
 		shaper_params.peak_burst   = idx * MIN_PEAK_BURST;
 
@@ -2474,8 +2474,8 @@ static int set_shaper(const char    *node_name,
 	}
 
 	odp_tm_shaper_params_init(&shaper_params);
-	shaper_params.commit_bps        = commit_bps;
-	shaper_params.peak_bps          = 0;
+	shaper_params.commit_rate       = commit_bps;
+	shaper_params.peak_rate         = 0;
 	shaper_params.commit_burst      = commit_burst_in_bits;
 	shaper_params.peak_burst        = 0;
 	shaper_params.shaper_len_adjust = 0;


### PR DESCRIPTION


commit 02c774cddd2121312f2d5e675c605c2388ddfef6
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Dec 30 00:02:07 2020 +0530

    api: tm: deprecate shaper cir and pir bps fields
    
    Deprecate commit_bps and peak_bps fields as they only related to
    byte mode and not packet mode. Instead commit_rate and peak_rate fields
    can be used in odp_tm_shaper_params_t
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit b9e817b08a98f7939106712a0a2f15fd46eb6774
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Dec 30 00:16:38 2020 +0530

    validation: tm: use commit_rate and peak_rate in shaper params
    
    Use commit_rate and peak_rate in odp_tm_shaper_params_t instead of
    commit_bps and peak_bps.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 407e4f1935502cdaf60ddc5b5795839b90f086cc
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Dec 30 00:12:19 2020 +0530

    example: tm: use commit_rate and peak_rate in shaper param
    
    Use commit_rate and peak_rate in shaper params instead of commit_bps
    and peak_bps.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 3e7d2f62ec8003ee9bea267056155aa7a65e61dc
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Wed Dec 30 00:10:15 2020 +0530

    linux-gen: tm: use commit_rate and peak_rate in shaper param
    
    Use commit_rate and peak_rate fields in odp_tm_shaper_params_t instead
    of commit_bps and peak_bps as *_rate fields denote rate in BPS when
    byte mode is set and PPS when packet mode is set.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>

commit 1173d0e778bdd9844521a22591573ddc591b4958
Author: Nithin Dabilpuram <ndabilpuram@marvell.com>
Date:   Fri Nov 6 20:48:35 2020 +0530

    api: tm: add option to enable packet mode in shaper
    
    Similar to using packet/frame count in scheduling
    algorithm and weight in units of number of packets,
    add option to enable packet mode in shaper
    by introducing a boolean flag in shaper profile params.
    When packet mode is set to TRUE, commit/peak rate is
    in PPS (packets per second) and commit/peak burst is in
    Packets.
    
    Signed-off-by: Nithin Dabilpuram <ndabilpuram@marvell.com>
